### PR TITLE
Add README's for Chrome Extension and Client Gen apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Clearnexus - Chrome Extension
+## Set up
+Clone the [repository][repository] with git:
+
+```
+$ git clone git@github.com:stackbuilders/clearnexus-chrome-extension.git
+```
+
+Add dependencies:
+
+```
+$ npm install
+$ bower install
+```
+
+## Compile
+Remember to run your Haskell application with the data types before compile the
+PureScript code. Compile the project and compress it with `pulp`:
+
+```
+$ pulp browserify --to extension/clearnexus.js
+```
+
+## Run
+Open your Google Chrome web browser and go to extensions.
+Enable `Developer mode` and choose the option `Load unpacked extension...`.
+Open the directory: `clearnexus-chrome-extension/extension/`. And use the extension
+in a Gmail session.
+
+[repository]: https://github.com/stackbuilders/clearnexus-chrome-extension

--- a/client-gen/README.md
+++ b/client-gen/README.md
@@ -1,0 +1,19 @@
+# Clearnexus - Chrome Extension - Client Gen
+## Set up
+In the directory: `clearnexus-chrome-extension/client-gen/`.
+
+Download dependencies and build the project:
+
+```
+$ stack build
+```
+
+NOTE: Rememeber to run `stack setup` to use a compatible `ghc` version.
+
+## Run
+Run the executable file:
+
+```
+$ stack exec client-gen-exe
+```
+


### PR DESCRIPTION
README's for the Chrome Extension and Client Gen apps. This will solve the [story about readme's][readmes]

[readmes]: https://trello.com/c/UsxsFGng/119-as-a-developer-i-want-a-readme-md-file-for-chrome-extension-so-that-i-have-a-place-where-i-can-put-the-documentation-of-the-proj